### PR TITLE
added Contact-us redirection to FAQs

### DIFF
--- a/src/app/about/faqs/components/FAQsContent.tsx
+++ b/src/app/about/faqs/components/FAQsContent.tsx
@@ -418,7 +418,9 @@ export default function FAQsContent() {
               </p>
               <div className=" flex w-full justify-center">
                 <button className=" rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white">
-                  Contact us
+                  <a href="/contact-us">
+                    Contact us
+                  </a>
                 </button>
               </div>
             </div>

--- a/src/app/about/faqs/components/FAQsContent.tsx
+++ b/src/app/about/faqs/components/FAQsContent.tsx
@@ -418,9 +418,9 @@ export default function FAQsContent() {
               </p>
               <div className=" flex w-full justify-center">
                 <button className=" rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white">
-                  <a href="/contact-us">
+                  <Link href="/contact-us">
                     Contact us
-                  </a>
+                  </Link>
                 </button>
               </div>
             </div>

--- a/src/app/about/faqs/components/FAQsContent.tsx
+++ b/src/app/about/faqs/components/FAQsContent.tsx
@@ -417,11 +417,9 @@ export default function FAQsContent() {
                 Still got questions? Reach out!
               </p>
               <div className=" flex w-full justify-center">
-                <button className=" rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white">
-                  <Link href="/contact-us">
-                    Contact us
-                  </Link>
-                </button>
+                <Link className=" button rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white" href="/contact-us">
+                  Contact us
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Added an <a></a> tag to handle redirection from FAQ Page contact-us button to the Contact Us page and form.

Testing Details: Tested the change on Chrome and Safari: Redirection works as expected.

