### PR TITLE
ABOUT-006 FAQ Alignment Fixes

### DIFF
--- a/src/app/about/faqs/components/FAQsContent.css
+++ b/src/app/about/faqs/components/FAQsContent.css
@@ -11,3 +11,11 @@
     background: #6F219E;
     border-radius: 5px;
   }
+  
+summary {
+    list-style: none;
+  }
+  
+summary::-webkit-details-marker {
+    display: none;
+}

--- a/src/app/about/faqs/components/FAQsContent.tsx
+++ b/src/app/about/faqs/components/FAQsContent.tsx
@@ -405,7 +405,7 @@ export default function FAQsContent() {
             ))}
           </div>
           <div>
-            <div className="w-[230px] rounded-2xl bg-[#FCF0D8] p-7">
+            <div className="w-[240px] rounded-2xl bg-[#FCF0D8] p-7 justify-items-center">
               <Image
                 className="mb-4"
                 src="/about/FAQs/CatImage.svg"

--- a/src/app/about/faqs/components/FAQsContent.tsx
+++ b/src/app/about/faqs/components/FAQsContent.tsx
@@ -406,6 +406,7 @@ export default function FAQsContent() {
           </div>
           <div>
             <div className="w-[240px] rounded-2xl bg-[#FCF0D8] p-7 justify-items-center">
+             <div className="flex w-full justify-center">
               <Image
                 className="mb-4"
                 src="/about/FAQs/CatImage.svg"
@@ -413,6 +414,7 @@ export default function FAQsContent() {
                 width={90}
                 height={90}
               />
+              </div>
               <p className="mb-4 text-[14px] font-semibold text-gray-800">
                 Still got questions? Reach out!
               </p>


### PR DESCRIPTION
- Fixed FAQ alignment rendering in Safari. Removed Default styling from summary tag: https://github.com/tailwindlabs/tailwindcss/discussions/13614
Before: <img width="1651" alt="Screenshot 2025-04-17 at 9 18 00 AM" src="https://github.com/user-attachments/assets/a8defeed-8186-4268-87ca-e8e753ebbed6" />
After:
<img width="1207" alt="Screenshot 2025-04-17 at 10 09 49 AM" src="https://github.com/user-attachments/assets/3f64e204-e332-4ef7-8e7c-b89f4625b8ca" />

- Centered the Cat image in the contact us box:
<img width="1016" alt="Screenshot 2025-04-17 at 10 10 17 AM" src="https://github.com/user-attachments/assets/08be8ef0-e61a-49b4-be3b-68181499aa4d" />
