### PR TITLE
add double-click to open  ebooks in lessons

### DIFF
--- a/src/app/(authorized)/lessons/components/EbooksComponent.tsx
+++ b/src/app/(authorized)/lessons/components/EbooksComponent.tsx
@@ -73,6 +73,10 @@ function EbooksComponent() {
                             `}
                             style={{ cursor: "pointer" }}
                             onClick={() => setSelected(i)}
+                            onDoubleClick={() => {
+                                setSelected(i);
+                                handleRead();
+                            }}
                         >
                             {
                                 selected==i?<SelectedCard width={210} height={210}>


### PR DESCRIPTION
This pull request introduces a small enhancement to the `EbooksComponent`. Now, double-clicking on an ebook card will both select the card and immediately trigger the `handleRead` action, improving the user experience for quickly opening ebooks.