### PR TITLE
Fix: prevent login redirect on access token expiry & fix cart Start shopping button

### DIFF
--- a/src/app/cart/components/EmptyCart.tsx
+++ b/src/app/cart/components/EmptyCart.tsx
@@ -1,4 +1,5 @@
 import ShoppingCartOutlined from "@mui/icons-material/ShoppingCartOutlined";
+import Link from "next/link";
 
 export default function EmptyCart() {
   return (
@@ -12,9 +13,13 @@ export default function EmptyCart() {
       <p className=" text-xl 3xl:text-2xl 4xl:text-3xl">
         Go back to the bookstore and start shopping
       </p>
-      <button className=" rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white">
+
+      <Link
+        href="/bookstore"
+        className="rounded-3xl bg-[#6F219E] px-14 py-2 text-[15px] font-semibold text-white"
+      >
         Start shopping
-      </button>
+      </Link>
     </div>
   );
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,51 +1,44 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
-
-const BACKEND_BASE_URL = process.env.NODE_ENV=="production"?process.env.BE_PROD_BASE_URL:process.env.BE_BASE_URL;
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+
+  // Skip Next.js internals and static assets
   if (
-    pathname.startsWith('/_next') ||
-    pathname.startsWith('/favicon.ico') ||
-    pathname.endsWith('.svg') ||
-    pathname.endsWith('.ico') ||
-    pathname.endsWith('.png') ||
-    pathname.endsWith('.jpg') ||
-    pathname.endsWith('.woff') ||
-    pathname.endsWith('.woff2') ||
-    pathname.endsWith('.ttf')
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/favicon.ico") ||
+    pathname.endsWith(".svg") ||
+    pathname.endsWith(".ico") ||
+    pathname.endsWith(".png") ||
+    pathname.endsWith(".jpg") ||
+    pathname.endsWith(".woff") ||
+    pathname.endsWith(".woff2") ||
+    pathname.endsWith(".ttf")
   ) {
     return NextResponse.next();
   }
 
-    const accessToken = request.cookies.get('access_token')?.value;
-    const refreshToken = request.cookies.get('refresh_token')?.value;
-    if (!accessToken) {      
-      return NextResponse.redirect(new URL('/login', request.url));
-    }
+  // Only protect dashboard/account routes (config matcher already limits this,
+  // but keeping this guard is harmless)
+  const isProtected = pathname.startsWith("/dashboard") || pathname.startsWith("/account");
+  if (!isProtected) return NextResponse.next();
 
-    try {       
-        const verifyResponse = await fetch(`${BACKEND_BASE_URL}/api/user/`, {
-          method: 'GET',
-          headers: {
-            Cookie: `access_token=${accessToken}; refresh_token=${refreshToken}`,
-          },
-          credentials: 'include',
-        });         
-        if (verifyResponse.status !==200) {           
-          return NextResponse.redirect(new URL('/login', request.url));
-        }
-    
-      } catch (error) {
-        console.error('Error verifying session:', error);
-        return NextResponse.redirect(new URL('/login', request.url));
-      }
+  const refreshToken = request.cookies.get("refresh_token")?.value;
+
+  // ✅ Key fix:
+  // If refresh token is missing, user is not authenticated -> redirect to login.
+  // If refresh token exists, allow navigation even if access token expired.
+  if (!refreshToken) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    url.searchParams.set("from", pathname);
+    return NextResponse.redirect(url);
+  }
+
   return NextResponse.next();
 }
 
-
-
 export const config = {
-  matcher: ['/dashboard/:path*', '/account/:path*'],
+  matcher: ["/dashboard/:path*", "/account/:path*"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,39 +1,23 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Skip Next.js internals and static assets
-  if (
-    pathname.startsWith("/_next") ||
-    pathname.startsWith("/favicon.ico") ||
-    pathname.endsWith(".svg") ||
-    pathname.endsWith(".ico") ||
-    pathname.endsWith(".png") ||
-    pathname.endsWith(".jpg") ||
-    pathname.endsWith(".woff") ||
-    pathname.endsWith(".woff2") ||
-    pathname.endsWith(".ttf")
-  ) {
+  const isProtected =
+    pathname.startsWith("/dashboard") ||
+    pathname.startsWith("/account");
+
+  if (!isProtected) {
     return NextResponse.next();
   }
 
-  // Only protect dashboard/account routes (config matcher already limits this,
-  // but keeping this guard is harmless)
-  const isProtected = pathname.startsWith("/dashboard") || pathname.startsWith("/account");
-  if (!isProtected) return NextResponse.next();
-
   const refreshToken = request.cookies.get("refresh_token")?.value;
 
-  // ✅ Key fix:
-  // If refresh token is missing, user is not authenticated -> redirect to login.
-  // If refresh token exists, allow navigation even if access token expired.
   if (!refreshToken) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/login";
-    url.searchParams.set("from", pathname);
-    return NextResponse.redirect(url);
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("from", pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,22 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-
-  const isProtected =
-    pathname.startsWith("/dashboard") ||
-    pathname.startsWith("/account");
-
-  if (!isProtected) {
-    return NextResponse.next();
-  }
-
   const refreshToken = request.cookies.get("refresh_token")?.value;
 
   if (!refreshToken) {
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = "/login";
-    loginUrl.searchParams.set("from", pathname);
+    loginUrl.searchParams.set("from", request.nextUrl.pathname);
     return NextResponse.redirect(loginUrl);
   }
 


### PR DESCRIPTION
## Summary
- Prevent redirect to login when access token expires (middleware update)
- Fix "Start shopping" button to correctly navigate to /bookstore

## Issue
After ~5 minutes, clicking "Edit" in dashboard redirected to login due to access_token cookie expiration.

## Solution
Middleware now checks refresh_token instead of access_token before redirecting.

## How to test
1. Login
2. Wait 5+ minutes
3. Click "Edit" in dashboard left navbar → should NOT redirect to login
4. Go to /cart empty state → click "Start shopping" → should navigate to /bookstore