### PR TITLE
fix: resolve accessibility issues across auth, contact, lessons, and …

### DIFF
--- a/src/app/(auth)/login/components/LoginForm.tsx
+++ b/src/app/(auth)/login/components/LoginForm.tsx
@@ -98,7 +98,7 @@ export default function LoginForm() {
                                 </svg>
                             </span>
                         </label>
-                        <label className="text-lg font-medium text-white mt-1 2xl:mt-2 3xl:text-2xl 4xl:text-[16px]">Remember me</label>
+                        <label htmlFor="check" className="text-lg font-medium text-white mt-1 2xl:mt-2 3xl:text-2xl 4xl:text-[16px]">Remember me</label>
                     </div>
                     <Link href="/forgot-password" className="text-lg font-medium text-primary-yellow mt-3 2xl:mt-4 3xl:text-2xl 4xl:text-[16px]">Forgot password?</Link>
                 </div>

--- a/src/app/(auth)/signup/components/SignupForm.tsx
+++ b/src/app/(auth)/signup/components/SignupForm.tsx
@@ -138,6 +138,30 @@ export default function SignupForm() {
             inputValue={confirmPassword}
           />
         )}
+        <Checkbox checked={isChecked} onChange={setIsChecked}>
+          <label
+            htmlFor="check"
+            className="text-l ms-2 mt-4 font-medium text-white 2xl:mt-6 2xl:text-2xl 4xl:mt-2"
+          >
+            I agree to The Donovan&apos;s piano room{" "}
+            <button
+              type="button"
+              onClick={() => handleOpenModal("terms")}
+              className="cursor-pointer text-primary-yellow underline"
+            >
+              terms of use
+            </button>{" "}
+            and{" "}
+            <button
+              type="button"
+              onClick={() => handleOpenModal("privacy")}
+              className="cursor-pointer text-primary-yellow underline"
+            >
+              privacy policy
+            </button>
+            .
+          </label>
+        </Checkbox>
         <div>
           <Button1
             onClick={handleSubmit}
@@ -145,28 +169,6 @@ export default function SignupForm() {
             text="Continue to verify account"
           />
         </div>
-        <Checkbox checked={isChecked} onChange={setIsChecked}>
-          <label
-            htmlFor="check"
-            className="text-l ms-2 mt-4 font-medium text-white 2xl:mt-6 2xl:text-2xl 4xl:mt-2"
-          >
-            I agree to The Donovan&apos;s piano room{" "}
-            <span
-              onClick={() => handleOpenModal("terms")}
-              className="cursor-pointer text-primary-yellow underline"
-            >
-              terms of use
-            </span>{" "}
-            and{" "}
-            <span
-              onClick={() => handleOpenModal("privacy")}
-              className="cursor-pointer text-primary-yellow underline"
-            >
-              privacy policy
-            </span>
-            .
-          </label>
-        </Checkbox>
       </form>
       <p className="2xl:rounded-4xl mt-9 mt-[10px] w-full rounded-3xl  bg-primary-purple py-3 text-center text-[12px] text-lg text-white 2xl:py-5 3xl:py-8 3xl:text-2xl">
         Already have an account?{" "}

--- a/src/app/(auth)/signup/components/TermsandCondition.tsx
+++ b/src/app/(auth)/signup/components/TermsandCondition.tsx
@@ -1,9 +1,24 @@
+"use client";
+import { useEffect, useRef } from 'react';
 import { TermsOfUseContent } from './TermsOfUseContent';
 import { PrivacyPolicyContent } from './PrivacyPolicyContent';
 import CloseIcon from '@mui/icons-material/Close';
 import '@/styles/primary-purple-scrollbar.css'
 
 const TermsandCondition = ({ isOpen, onClose, content }: { isOpen: boolean; onClose: () => void; content: 'terms' | 'privacy' }) => {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const dialogTitle = content === 'terms' ? 'Terms of Use' : 'Privacy Policy';
+
+  useEffect(() => {
+    if (!isOpen) return;
+    closeButtonRef.current?.focus();
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const getContent = () => {
@@ -18,20 +33,30 @@ const TermsandCondition = ({ isOpen, onClose, content }: { isOpen: boolean; onCl
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
-    <div className="bg-white p-6 rounded-lg max-w-[30vw] w-full relative">
-      <button onClick={onClose} className="absolute top-2 right-2 text-red-500">
-        <CloseIcon className="text-3xl font-bold 3xl:text-3xl 4xl:text-4xl text-primary-purple" />
-      </button>
-      <div className=" mt-[2%] overflow-y-auto max-h-[70vh]">
-        <div className="text-black">
-          <div className="text-base md:text-lg">
-            {getContent()}
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-label={dialogTitle}
+    >
+      <div className="bg-white p-6 rounded-lg max-w-[30vw] w-full relative">
+        <button
+          ref={closeButtonRef}
+          onClick={onClose}
+          aria-label="Close dialog"
+          className="absolute top-2 right-2 text-red-500"
+        >
+          <CloseIcon className="text-3xl font-bold 3xl:text-3xl 4xl:text-4xl text-primary-purple" />
+        </button>
+        <div className=" mt-[2%] overflow-y-auto max-h-[70vh]">
+          <div className="text-black">
+            <div className="text-base md:text-lg">
+              {getContent()}
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
   );
 };
 

--- a/src/app/(authorized)/lessons/components/EbooksComponent.tsx
+++ b/src/app/(authorized)/lessons/components/EbooksComponent.tsx
@@ -67,11 +67,16 @@ function EbooksComponent() {
                         <div
                             key={book.id}
                             className={`
-                                relative 
+                                relative
                                 transition-all duration-300
-                                
+
                             `}
-                            style={{ cursor: "pointer" }}
+                        >
+                        <button
+                            type="button"
+                            aria-label={`Select ${book.title}`}
+                            aria-pressed={selected === i}
+                            style={{ cursor: "pointer", background: "none", border: "none", padding: 0 }}
                             onClick={() => setSelected(i)}
                         >
                             {
@@ -79,19 +84,19 @@ function EbooksComponent() {
                                 <Image
                                     className="object-contain w-[210px] h-[210px] transition-all duration-300"
                                     src={book.imgsrc}
-                                    alt="ebook image"
+                                    alt={`${book.title} cover (selected)`}
                                     width={210}
                                     height={210}
                                 />
                             </SelectedCard>:<Image
                                     className="object-contain w-[210px] h-[210px] transition-all duration-300"
                                     src={book.imgsrc}
-                                    alt="ebook image"
+                                    alt={`${book.title} cover`}
                                     width={210}
                                     height={210}
                                 />
                             }
-                            
+                        </button>
                         </div>
                     ))}
                 </div>
@@ -108,9 +113,10 @@ function EbooksComponent() {
                     <div className="flex-[1]">
                         <button
                             className="bg-primary-purple text-white text-xl block mx-auto my-4 px-10 py-3 rounded-3xl"
+                            aria-label={`Read and practice ${ebooks[selected].title}`}
                             onClick={handleRead}
                         >
-                            Read & Practice
+                            Read &amp; Practice
                         </button>
                     </div>
 
@@ -119,6 +125,16 @@ function EbooksComponent() {
             {
                 read && <div>
                     <button onClick={handleBack}>Go Back to All Books</button>
+                    <p className="text-sm text-primary-gray mt-2 mb-1">
+                        Having trouble accessing this e-book with assistive technology?{" "}
+                        <a
+                            href="mailto:info@theDonovan.org"
+                            className="text-primary-purple underline"
+                        >
+                            Contact us
+                        </a>{" "}
+                        to request an accessible version.
+                    </p>
                     <ReaderPortal onClose={() => setRead(false)}>
                         <iframe
                             src={ebooks[selected].url}

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -55,9 +55,13 @@ const Games = () => {
   if (loading) {
     return (
       <>
-        <div className="w-[80%] mt-[9vh] mx-auto flex flex-col items-center justify-center flex-grow">
-          <CircularProgress size={60} />
-          <p className="mt-4 text-gray-600">Loading...</p>
+        <div
+          role="status"
+          aria-live="polite"
+          className="w-[80%] mt-[9vh] mx-auto flex flex-col items-center justify-center flex-grow"
+        >
+          <CircularProgress size={60} aria-hidden="true" />
+          <p className="mt-4 text-gray-600">Loading games, please wait…</p>
         </div>
       </>
     );
@@ -68,6 +72,10 @@ const Games = () => {
       {!isAuthenticated &&
         <div className="w-[80%] mt-[9vh] mx-auto flex-grow">
           <h1 className="text-5xl font-bold text-gray-800 mb-8">Games</h1>
+          <p className="sr-only">
+            The music games include a note identification quiz. If you use assistive technology and need help with the quiz,
+            please contact us at info@theDonovan.org for support.
+          </p>
 
           <div className="bg-white rounded-lg border border-gray-200 p-8">
             <div className="flex items-center gap-3 mb-6">

--- a/src/components/atoms/form-input.tsx
+++ b/src/components/atoms/form-input.tsx
@@ -36,6 +36,7 @@ export default function InputForm({
           {field.required && <span className="text-red-500 ml-1">*</span>}
         </InputLabel>
         <Input
+          id={field.name}
           className='w-full pl-5 text-[16px]'
           type={field.type}
           value={text}

--- a/src/components/auth/AuthContentWrapper.tsx
+++ b/src/components/auth/AuthContentWrapper.tsx
@@ -8,7 +8,7 @@ export default function AuthContentWrapper({children}: {children: React.ReactNod
     <div className='bg-primary-purple'>
         <Navbar2 />
         <BackgroundSignup/>
-        <section className='relative z-40 mx-auto flex flex-col items-center justify-center px-4 py-8 md:h-screen'>
+        <section className='relative z-40 mx-auto flex flex-col items-center justify-center px-4 min-h-screen pt-[calc(9.5vh+2rem)] pb-[calc(9.3vh+2rem)]'>
           {children}
 
         </section>

--- a/src/components/auth/password-input.tsx
+++ b/src/components/auth/password-input.tsx
@@ -18,8 +18,9 @@ export default function PasswordInput({ onChange, name, label, error, inputValue
     <div>
 
       <FormControl variant="filled" sx={{ border: 1, borderColor: '#391f0f'}} error={!!error} className='bg-[#fef8ee] hover:bg-[#FCF0D8] focus:bg-[#FCF0D8] block rounded-3xl w-full 2xl:mb-[25px] 2xl:py-2 3xl:py-4'>
-          <InputLabel className='3xl:text-2xl 3xl:mt-3' sx={[{color: "#391f0f"},!error && {'&.Mui-focused': {color: "#391f0f"}}]} htmlFor="standard-adornment-password">{label}</InputLabel>
+          <InputLabel className='3xl:text-2xl 3xl:mt-3' sx={[{color: "#391f0f"},!error && {'&.Mui-focused': {color: "#391f0f"}}]} htmlFor={name}>{label}</InputLabel>
           <Input
+              id={name}
               required
               value={inputValue}
               sx={{border: 0}}


### PR DESCRIPTION
…games pages

Fix label/input association on all form fields by adding id={field.name} to MUI Input and id={name} to PasswordInput so each label's htmlFor resolves to a real DOM id. Affects login, signup, and contact us forms.

Fix TermsandCondition modal: add aria-label="Close dialog" to the × button, add role="dialog" aria-modal="true" aria-label on the overlay, auto-focus the close button on open, and close on Escape key press.

Fix SignupForm: change TOS and Privacy Policy spans to <button type="button">
so they are keyboard-tabbable. Move the "I agree" checkbox above the submit button so screen reader users encounter it before the continue action.

Fix LoginForm: add htmlFor="check" to the "Remember me" label so clicking it toggles the checkbox.

Fix AuthContentWrapper: replace md:h-screen with min-h-screen and add pt-[calc(9.5vh+2rem)] pb-[calc(9.3vh+2rem)] so form content is never clipped behind the fixed navbar or footer, including at high zoom levels.

Fix EbooksComponent: wrap book cover images in <button aria-label aria-pressed>
for keyboard and screen reader access, add descriptive per-book alt text, and show a contact link for users who need an accessible version of the Heyzine flipbook.

Fix games page: add role="status" aria-live="polite" to the loading state and a sr-only note directing assistive technology users to contact support for the external quiz, which cannot be modified from this codebase.