### PR TITLE
Fixed signup flow with basic/scholarship tiers and deferred account c…

### DIFF
--- a/src/app/(auth)/signup/components/AllSignupSteps.tsx
+++ b/src/app/(auth)/signup/components/AllSignupSteps.tsx
@@ -1,9 +1,10 @@
 import { singupStepAtom } from '@/utils/stores'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import SignupForm from './SignupForm'
 import SignupMembershipContent from './membership/SignupMembershipContent'
 import EmailVerificationContent from './email-verification/components/EmailVerificationContent'
 import SignupPayment from './SignupPayment'
+import SignupConfirmation from './SignUpConfirmation'
 
 export default function AllSignupSteps() {
 
@@ -13,7 +14,8 @@ export default function AllSignupSteps() {
         { signupStep === 1 && (<SignupForm/>) }
         { signupStep === 2 && (<EmailVerificationContent />)}
         { signupStep === 3 && (<SignupMembershipContent />)}
-        {signupStep === 4 && (<SignupPayment/>)}
+        { signupStep === 4 && (<SignupPayment/>)}
+        { signupStep === 5 && (<SignupConfirmation/>)}
     </>
   )
 }

--- a/src/app/(auth)/signup/components/SignUpConfirmation.tsx
+++ b/src/app/(auth)/signup/components/SignUpConfirmation.tsx
@@ -1,23 +1,96 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import AuthSucceedWrapper from "@/components/auth/AuthSucceedWrapper";
+import { singupStepAtom, membershipChoiceAtom, membershipTypes, profileAtom } from "@/utils/stores";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useEffect, useState } from "react";
+import { completeSignup } from "@/lib/api/authService";
+
+const membershipLabels: Record<string, string> = {
+    [membershipTypes["24-hours"]]: "24-Hour",
+    [membershipTypes["monthly-access"]]: "Monthly",
+    [membershipTypes["yearly-access"]]: "Yearly",
+    [membershipTypes["basic"]]: "Basic",
+    [membershipTypes["scholarship"]]: "Scholarship",
+}
 
 export default function SignupConfirmation() {
+    const membershipChoice = useAtomValue(membershipChoiceAtom)
+    const { email } = useAtomValue(profileAtom)
+    const resetStep = useSetAtom(singupStepAtom)
+    const resetMembership = useSetAtom(membershipChoiceAtom)
+    const router = useRouter()
+
+    const [label] = useState(() => membershipLabels[membershipChoice] ?? "")
+    const [capturedEmail] = useState(() => email)
+
+    const [isLoading, setIsLoading] = useState(true)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        const finish = async () => {
+            try {
+                const { ok, data } = await completeSignup(capturedEmail)
+                if (!ok) {
+                    setError(data?.message || 'Failed to complete signup. Please try again.')
+                    return
+                }
+            } catch {
+                setError('Failed to complete signup. Please try again.')
+            } finally {
+                setIsLoading(false)
+            }
+        }
+        finish()
+    }, [])
+
+    const handleLogin = () => {
+        resetStep(1)
+        resetMembership("")
+        router.push('/login')
+    }
+
+    if (isLoading) {
+        return (
+            <AuthSucceedWrapper>
+                <div className="flex items-center justify-center py-10">
+                    <div className="w-12 h-12 border-4 border-white border-t-transparent rounded-full animate-spin" />
+                </div>
+            </AuthSucceedWrapper>
+        )
+    }
+
+    if (error) {
+        return (
+            <AuthSucceedWrapper>
+                <h1 className="text-4xl md:text-8xl 2xl:text-8xl 4xl:text-9xl leading-tight tracking-tight text-white mb-5 font-montserrat">
+                    Something went wrong
+                </h1>
+                <p className="text-white text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl mb-5">{error}</p>
+                <p className="w-full text-center bg-primary-yellow-accent py-4 rounded-full text-primary-purple font-bold text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl">
+                    <Link href="/signup">Try again</Link>
+                </p>
+            </AuthSucceedWrapper>
+        )
+    }
+
     return (
         <AuthSucceedWrapper>
             <h1 className="text-4xl md:text-8xl 2xl:text-8xl 4xl:text-9xl leading-tight tracking-tight text-white mb-5 font-montserrat">
                 Hurray! You&apos;re in
             </h1>
             <div className="mb-5 2xl:mt-5 2xl:mb-[20px]">
-                <p className="text-white text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl">Your access is now active and your account has been created</p>
-                <p className="mt-9 w-full text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl text-white">
-                    Didn&apos;t receive the link? <Link href="#" className="text-primary-yellow-accent underline">Resend one</Link>
+                <p className="text-white text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl">
+                    Your {label} access is now active and your account has been created.
                 </p>
             </div>
-            <p className="w-full text-center bg-primary-yellow-accent py-4 rounded-full text-primary-purple font-bold text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl">
-                <Link href="/login">Log in</Link>
-            </p>
+            <button
+                onClick={handleLogin}
+                className="w-full text-center bg-primary-yellow-accent py-4 rounded-full text-primary-purple font-bold text-lg md:text-xl 2xl:text-2xl 4xl:text-3xl"
+            >
+                Log in
+            </button>
         </AuthSucceedWrapper>
     );
 }

--- a/src/app/(auth)/signup/components/membership/MembershipIncludes.tsx
+++ b/src/app/(auth)/signup/components/membership/MembershipIncludes.tsx
@@ -1,36 +1,48 @@
 import Button1 from "@/components/atoms/Button1"
-import Button2 from "@/components/atoms/Button2"
 import InputForm from "@/components/atoms/form-input"
-import { validateCouponCode } from "@/lib/api/membershipService"
+import { validateCouponCode, validateScholarshipCode } from "@/lib/api/membershipService"
 import { membershipTypes, membershipChoiceAtom } from "@/utils/stores"
-import { stat } from "fs"
 import { useAtomValue } from "jotai"
 import Image from "next/image"
 import { useEffect, useState } from "react"
-import { set } from "zod"
 
 export default function MembershipIncludes() {
     const [showDiscountInput, setShowDiscountInput] = useState(false)
     const [discountCode, setDiscountCode] = useState("")
+    const [scholarshipCode, setScholarshipCode] = useState("")
     const membershipChoice = useAtomValue(membershipChoiceAtom)
     const membershipChoiceContent = membershipIncludes[membershipChoice];
     const [status, setStatus] = useState<null | "success" | "error">(null);
     const [isLoading, setIsLoading] = useState(false);
 
+    const isScholarship = membershipChoice === membershipTypes["scholarship"]
+    const isPaid = !isScholarship && membershipChoice !== membershipTypes["basic"]
+
     useEffect(() => {
-        // Reset the discount input and status when membershipChoice changes
         setShowDiscountInput(false)
         setDiscountCode("")
+        setScholarshipCode("")
         setStatus(null)
     }, [membershipChoice])
 
     const applyCouponCode = async () => {
         try {
             setIsLoading(true);
-            const isValid = await validateCouponCode(membershipChoiceContent.id, discountCode);
-            console.log(isValid);
+            await validateCouponCode(membershipChoiceContent.id, discountCode);
             setStatus("success");
-        } catch (error) {
+        } catch {
+            setStatus("error");
+        } finally {
+            setIsLoading(false);
+        }
+    }
+
+    const applyScholarshipCode = async () => {
+        try {
+            setIsLoading(true);
+            await validateScholarshipCode(scholarshipCode);
+            setStatus("success");
+        } catch {
             setStatus("error");
         } finally {
             setIsLoading(false);
@@ -40,43 +52,113 @@ export default function MembershipIncludes() {
     return membershipChoice && (
         <div className="fixed right-[25vw] 3xl:right-[23vw] w-[24vw] 3xl:w-[26vw] bg-tertiary-purple h-auto rounded-3xl p-6">
 
-            <h3 className="text-primary-yellow border-b-2 border-b-primary-yellow flex gap-2 text-[16px] 2xl:text-3xl 4xl:text-4xl font-semibold pb-3 4xl:pb-6"><Image src="/auth/membershipTitleWaring.svg" width={20} height={20} alt="" /> {membershipChoiceContent.title}</h3>
-            <ul className="my-4 border-b-2 border-primary-purple pb-3 4xl:pb-6">
+            <h3 className="text-primary-yellow border-b-2 border-b-primary-yellow flex items-center gap-2 text-[16px] 2xl:text-3xl 4xl:text-4xl font-bold pb-3 4xl:pb-6">
+                <span className="flex-shrink-0 w-5 h-5 2xl:w-8 2xl:h-8 rounded-full border-2 border-primary-yellow flex items-center justify-center text-primary-yellow text-[11px] 2xl:text-lg font-bold">i</span>
+                {membershipChoiceContent.title}
+            </h3>
+
+            <ul className="my-4 border-b-2 border-primary-purple pb-3 4xl:pb-6 flex flex-col gap-3 2xl:gap-5">
                 {membershipChoiceContent.content.map((item, i) => (
-                    <li className="text-white mt-2 4xl:mt-4" key={i}>
-                        <p className="text-[12px] 2xl:text-2xl 4xl:text-3xl ">
-                            <span className="font-semibold mr-1">{item[0]}</span>{item[1]}
-                        </p>
+                    <li className="flex gap-3 items-start" key={i}>
+                        <span className="flex-shrink-0 w-5 h-5 2xl:w-8 2xl:h-8 4xl:w-10 4xl:h-10 rounded-full bg-primary-yellow flex items-center justify-center mt-[2px]">
+                            <svg className="w-3 h-3 2xl:w-5 2xl:h-5" viewBox="0 0 12 10" fill="none">
+                                <path d="M1 5L4.5 8.5L11 1.5" stroke="#3B1E7A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                        </span>
+                        <div className="flex flex-col">
+                            <span className="text-white font-semibold text-[12px] 2xl:text-2xl 4xl:text-3xl">{item[0].replace(/:$/, '')}</span>
+                            <span className="text-white/80 text-[11px] 2xl:text-xl 4xl:text-2xl leading-snug mt-[2px]">{item[1]}</span>
+                        </div>
                     </li>
                 ))}
             </ul>
-            <div>
-                {status === "success" ?
-                    <p className="flex items-center gap-2 mb-2">
-                        <Image src="/Success.svg" width={18} height={18} alt="" /><span className="text-white text-[12px] 4xl:text-2xl 2xl:text-4xl">Discound code applied</span></p>
-                    : <p className="text-white text-[12px] 4xl:text-2xl 2xl:text-4xl mb-2 4xl:mt-4">Enter your discount code <span className="text-primary-yellow underline cursor-pointer" onClick={() => setShowDiscountInput(prev => !prev)}>here</span></p>
-                }
 
-                {showDiscountInput &&
-                    <div className="flex items-center">
-                        <div style={{ flex: status !== "success" ? 1 : 'none' }}>
+            {/* Scholarship code input */}
+            {isScholarship && (
+                <div>
+                    {status === "success" ? (
+                        <>
+                            <p className="flex items-center gap-2 mb-3">
+                                <span className="flex-shrink-0 w-5 h-5 2xl:w-7 2xl:h-7 rounded-full bg-primary-yellow flex items-center justify-center">
+                                    <svg className="w-3 h-3 2xl:w-4 2xl:h-4" viewBox="0 0 12 10" fill="none">
+                                        <path d="M1 5L4.5 8.5L11 1.5" stroke="#3B1E7A" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                                    </svg>
+                                </span>
+                                <span className="text-white text-[12px] 2xl:text-xl 4xl:text-2xl">Scholarship code verified successfully</span>
+                            </p>
                             <InputForm
-
-                                onChange={(e: any) => setDiscountCode(e.target.value)}
-                                field={{ type: "text", name: "discount-code", label: "Discount code" }}
-                                text={discountCode} error={status === "error" ? "Invalid discount code, please try again" : ""}
-                                disabled={status === "success"}
+                                onChange={() => {}}
+                                field={{ type: "text", name: "scholarship-code", label: "Scholarship code" }}
+                                text={scholarshipCode}
+                                error=""
+                                disabled={true}
                             />
+                        </>
+                    ) : (
+                        <>
+                            <div className="flex items-center gap-2">
+                                <div className="flex-1">
+                                    <InputForm
+                                        onChange={(e: any) => setScholarshipCode(e.target.value)}
+                                        field={{ type: "text", name: "scholarship-code", label: "Scholarship code" }}
+                                        text={scholarshipCode}
+                                        error={status === "error" ? "Invalid scholarship code, please try again" : ""}
+                                        disabled={false}
+                                    />
+                                </div>
+                                <Button1
+                                    style={{ marginLeft: "4px", width: "89px", height: "40px" }}
+                                    disabled={isLoading || !scholarshipCode}
+                                    text="Apply"
+                                    onClick={applyScholarshipCode}
+                                />
+                            </div>
+                        </>
+                    )}
+                </div>
+            )}
+
+            {/* Discount code input for paid tiers */}
+            {isPaid && (
+                <div>
+                    {status === "success" ? (
+                        <p className="flex items-center gap-2 mb-2">
+                            <Image src="/Success.svg" width={18} height={18} alt="" />
+                            <span className="text-white text-[12px] 4xl:text-2xl 2xl:text-4xl">Discount code applied</span>
+                        </p>
+                    ) : (
+                        <p className="text-white text-[12px] 4xl:text-2xl 2xl:text-4xl mb-2 4xl:mt-4">
+                            Enter your discount code <span className="text-primary-yellow underline cursor-pointer" onClick={() => setShowDiscountInput(prev => !prev)}>here</span>
+                        </p>
+                    )}
+                    {showDiscountInput && (
+                        <div className="flex items-center">
+                            <div style={{ flex: status !== "success" ? 1 : 'none' }}>
+                                <InputForm
+                                    onChange={(e: any) => setDiscountCode(e.target.value)}
+                                    field={{ type: "text", name: "discount-code", label: "Discount code" }}
+                                    text={discountCode}
+                                    error={status === "error" ? "Invalid discount code, please try again" : ""}
+                                    disabled={status === "success"}
+                                />
+                            </div>
+                            {status !== "success" && (
+                                <Button1
+                                    style={{ marginLeft: "4px", width: "89px", height: "40px" }}
+                                    disabled={isLoading}
+                                    text="Apply"
+                                    onClick={applyCouponCode}
+                                />
+                            )}
                         </div>
-                        {status !== "success" && <Button1 style={{ "margin-left": "4px", "width": "89px", "height": "40px" }} disabled={isLoading} text="Apply" onClick={applyCouponCode} />}
-                    </div>
-                }
-            </div>
+                    )}
+                </div>
+            )}
         </div>
     )
 }
 
-const membershipIncludes = {
+const membershipIncludes: Record<string, { id: number; title: string; content: string[][] }> = {
     [membershipTypes["24-hours"]]: {
         id: 1,
         title: "24 hour access",
@@ -90,26 +172,35 @@ const membershipIncludes = {
         id: 2,
         title: "Monthly access",
         content: [
-            ["Flexibility:", 'A great way to explore all the wonderful games, tools, and resources The Donovans Piano Room offers, without the long-term commitment. Members can cancel their subscription anytime.'],
+            ["Flexibility:", "A great way to explore all the wonderful games, tools, and resources The Donovans Piano Room offers, without the long-term commitment. Members can cancel their subscription anytime."],
             ["Full Access:", "The Monthly Membership allows you to explore all of our musical education tools, including voice lessons, ear training, and more. Monthly members can take advantage of live lessons and their recordings, as well as new and exciting content."],
             ["Progress Tracking:", "With a monthly membership, you have access to your personalized game scoreboard. You can track your progress and see how much you've learned over time!"]
-        ]
-    },
-    [membershipTypes["scholarship"]]: {
-        id: 3,
-        title: "Scholarship access",
-        content: [
-            ["Full Access:", "Students are provided with  full access to The Donovan's Piano Room, where they can use the many games, tools, and resources, to enhance their musical education."],
-            ["Eligibility:", "Scholarships are available for individuals aged 21 and younger, and those aged 60 and older. Eligibility for the scholarships is based on family income being below the Federal Poverty Level (FPL)."]
         ]
     },
     [membershipTypes["yearly-access"]]: {
         id: 4,
         title: "Yearly access",
         content: [
-            ["Cost savings:", "By opting for the yearly subscription, you generally receive a discounted reate compared to the monthly subscription. In this case, the yearly option offers a cost savings of $59.89 compared to paying for 12 months individually."],
+            ["Cost savings:", "By opting for the yearly subscription, you generally receive a discounted rate compared to the monthly subscription. In this case, the yearly option offers a cost savings of $59.89 compared to paying for 12 months individually."],
             ["Long-term commitment:", "Choosing the yearly subscription shows a commitment to the program, which can be beneficial if you have a positive experience and intend to use it consistently throughout the year."]
         ]
-    }
-
+    },
+    [membershipTypes["basic"]]: {
+        id: 5,
+        title: "Basic access",
+        content: [
+            ["Free to start:", "Sign up at no cost and explore the platform with no payment required."],
+            ["Limited access:", "Try a small set of games and resources to preview the experience before committing."],
+            ["Upgrade path available:", "Unlock progress tracking, the full library, and community features by moving to a paid membership or applying for a scholarship."]
+        ]
+    },
+    [membershipTypes["scholarship"]]: {
+        id: 3,
+        title: "Scholarship Access",
+        content: [
+            ["Full access:", "Enjoy the same benefits as a paid membership, which includes the complete library of games, tools, and resources."],
+            ["Eligibility:", "Available for learners aged 21 and younger (or 60 and older) based on family income requirements."],
+            ["Apply or redeem:", "Enter a scholarship code if you already have one, or apply to request eligibility."]
+        ]
+    },
 }

--- a/src/app/(auth)/signup/components/membership/MembershipSelctionLayout.tsx
+++ b/src/app/(auth)/signup/components/membership/MembershipSelctionLayout.tsx
@@ -1,54 +1,80 @@
 import { membershipChoiceAtom, membershipTypes, singupStepAtom } from "@/utils/stores";
 import { useAtom, useSetAtom } from "jotai";
-import Image from "next/image";
 import Link from "next/link";
 import SignupHeader from "../SignupHeader";
 import Button2 from "@/components/atoms/Button2";
 
+const FREE_MEMBERSHIP_TYPES = [membershipTypes["basic"], membershipTypes["scholarship"]];
+
 export default function MembershipSelctionLayout() {
     const [membershipChoice, setMembershipChoice] = useAtom(membershipChoiceAtom)
     const setSingupStep = useSetAtom(singupStepAtom)
-    const goToPayment = (e: any) =>{
+
+    const isFree = FREE_MEMBERSHIP_TYPES.includes(membershipChoice)
+
+    const handleContinue = (e: any) => {
         e.preventDefault()
-        setSingupStep(stepN => stepN+1)
+        setSingupStep(isFree ? 5 : 4)
     }
-  return (
-    <section className={membershipChoice ? 'absolute left-[25vw] 3xl:left-[23vw]' : ''}>
-        <SignupHeader stepName="Select your membership" stepNum={3} navLink="/" navName="Account" />
-        <form>
-            <fieldset className="flex flex-col w-[24vw] 3xl:w-[26vw]">
-                <label className="flex gap-3 w-full py-5 2xl:py-7 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-6" onClick={() => setMembershipChoice(membershipTypes["24-hours"])}>
-                    <input type="radio" className="w-6 h-6 accent-primary-purple bg-[#FEF8EE]" name="membership_option" value="1" required/>
-                    <div className="w-full flex justify-between text-[12px] font-semibold 2xl:text-2xl 4xl:text-3xl">
-                        <p className="text-primary-brown">24 hour membership</p>
-                        <p className="text-">$1.99 now</p>
-                    </div>
-                </label>
-                <label className="flex gap-3 w-full py-5 2xl:py-7 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-6" onClick={() => setMembershipChoice(membershipTypes["monthly-access"])}>
-                    <input type="radio" className="w-6 h-6 accent-primary-purple bg-[#FEF8EE]" name="membership_option" value="2" required/>
-                    <div className="w-full flex justify-between text-[12px] font-semibold 2xl:text-2xl 4xl:text-3xl">
-                        <p className="text-primary-brown">Monthly membership</p>
-                        <p className="text-">$29.99/month</p>
-                    </div>
-                </label>
-                <label className="flex gap-3 w-full py-5 2xl:py-7 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-6" onClick={() => setMembershipChoice(membershipTypes["yearly-access"])}>
-                    <input type="radio" className="w-6 h-6 accent-primary-purple bg-[#FEF8EE]" name="membership_option" value="2" required/>
-                    <div className="w-full flex justify-between text-[12px] font-semibold 2xl:text-2xl 4xl:text-3xl">
-                        <p className="text-primary-brown">Yearly membership</p>
-                        <p className="text-">$239.88/year</p>
-                    </div>
-                </label>
-                <label className="flex gap-3 w-full py-5 2xl:py-7 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-6" onClick={() => setMembershipChoice(membershipTypes["scholarship"])}>
-                    <input type="radio" className="w-6 h-6 accent-primary-purple bg-[#FEF8EE]" name="membership_option" value="2" required/>
-                    <div className="w-full flex justify-between text-[12px] font-semibold 2xl:text-2xl 4xl:text-3xl">
-                        <p className="text-primary-brown">Scholarship</p>
-                        <p className="text-">Free</p>
-                    </div>
-                </label>
-            </fieldset>
-            <Button2 text="Continue to payment method" onClick={goToPayment}/>
-        </form>
-        <p className='w-full text-center text-lg 3xl:text-2xl text-white bg-primary-purple py-3 rounded-[15px] text-[12px] mt-9 2xl:py-5 2xl:rounded-full'>Already have an account? <Link href="/login" className='text-primary-yellow underline'>Log in</Link></p>
-    </section>
-  )
+
+    const buttonText = isFree ? "Continue" : "Continue to payment method"
+
+    return (
+        <section className={membershipChoice ? 'absolute left-[25vw] 3xl:left-[23vw]' : ''}>
+            <SignupHeader stepName="Select your membership" stepNum={3} navLink="/" navName="Account" />
+            <form>
+                <fieldset className="flex flex-col w-[24vw] 3xl:w-[26vw]">
+
+                    {/* 24-Hour */}
+                    <label className="flex gap-3 items-center w-full py-4 2xl:py-6 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-4 cursor-pointer" onClick={() => setMembershipChoice(membershipTypes["24-hours"])}>
+                        <input type="radio" className="w-5 h-5 2xl:w-7 2xl:h-7 accent-primary-purple flex-shrink-0" name="membership_option" value="1" required />
+                        <div className="flex flex-col">
+                            <p className="text-primary-brown font-bold text-[13px] 2xl:text-2xl 4xl:text-3xl">24-Hour membership</p>
+                            <p className="text-primary-brown text-[11px] 2xl:text-xl 4xl:text-2xl">$1.99 now</p>
+                        </div>
+                    </label>
+
+                    {/* Monthly */}
+                    <label className="flex gap-3 items-center w-full py-4 2xl:py-6 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-4 cursor-pointer" onClick={() => setMembershipChoice(membershipTypes["monthly-access"])}>
+                        <input type="radio" className="w-5 h-5 2xl:w-7 2xl:h-7 accent-primary-purple flex-shrink-0" name="membership_option" value="2" required />
+                        <div className="flex flex-col">
+                            <p className="text-primary-brown font-bold text-[13px] 2xl:text-2xl 4xl:text-3xl">Monthly membership</p>
+                            <p className="text-primary-brown text-[11px] 2xl:text-xl 4xl:text-2xl">$29.99/month</p>
+                        </div>
+                    </label>
+
+                    {/* Yearly — most popular */}
+                    <label className="flex gap-3 items-center w-full py-4 2xl:py-6 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-4 cursor-pointer" onClick={() => setMembershipChoice(membershipTypes["yearly-access"])}>
+                        <input type="radio" className="w-5 h-5 2xl:w-7 2xl:h-7 accent-primary-purple flex-shrink-0" name="membership_option" value="3" required />
+                        <div className="flex flex-col flex-1">
+                            <p className="text-primary-brown font-bold text-[13px] 2xl:text-2xl 4xl:text-3xl">Yearly membership</p>
+                            <p className="text-primary-brown text-[11px] 2xl:text-xl 4xl:text-2xl">$239.88/year</p>
+                        </div>
+                        <span className="flex-shrink-0 bg-primary-yellow text-primary-purple text-[10px] 2xl:text-base 4xl:text-xl font-semibold px-2 py-1 2xl:px-3 2xl:py-1.5 rounded-full">most popular</span>
+                    </label>
+
+                    {/* Basic */}
+                    <label className="flex gap-3 items-center w-full py-4 2xl:py-6 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-4 cursor-pointer" onClick={() => setMembershipChoice(membershipTypes["basic"])}>
+                        <input type="radio" className="w-5 h-5 2xl:w-7 2xl:h-7 accent-primary-purple flex-shrink-0" name="membership_option" value="4" required />
+                        <div className="flex flex-col">
+                            <p className="text-primary-brown font-bold text-[13px] 2xl:text-2xl 4xl:text-3xl">Basic membership</p>
+                            <p className="text-primary-brown text-[11px] 2xl:text-xl 4xl:text-2xl">Free (limited access)</p>
+                        </div>
+                    </label>
+
+                    {/* Scholarship */}
+                    <label className="flex gap-3 items-center w-full py-4 2xl:py-6 3xl:py-8 px-5 bg-[#FEF8EE] rounded-2xl mb-4 cursor-pointer" onClick={() => setMembershipChoice(membershipTypes["scholarship"])}>
+                        <input type="radio" className="w-5 h-5 2xl:w-7 2xl:h-7 accent-primary-purple flex-shrink-0" name="membership_option" value="5" required />
+                        <div className="flex-1">
+                            <p className="text-primary-brown font-bold text-[13px] 2xl:text-2xl 4xl:text-3xl">Scholarship</p>
+                        </div>
+                        <span className="flex-shrink-0 text-primary-brown font-semibold text-[11px] 2xl:text-xl 4xl:text-2xl">Apply or redeem</span>
+                    </label>
+
+                </fieldset>
+                <Button2 text={buttonText} onClick={handleContinue} />
+            </form>
+            <p className='w-full text-center text-lg 3xl:text-2xl text-white bg-primary-purple py-3 rounded-[15px] text-[12px] mt-9 2xl:py-5 2xl:rounded-full'>Already have an account? <Link href="/login" className='text-primary-yellow underline'>Log in</Link></p>
+        </section>
+    )
 }

--- a/src/lib/api/authService.ts
+++ b/src/lib/api/authService.ts
@@ -126,6 +126,16 @@ export const resetPassword = async (passwordResetToken: string, newPassword: str
     return {data, ok: response.ok}
 }
 
+export const completeSignup = async (email: string) => {
+    const response = await fetch('/api/auth/complete-signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+    });
+    const data = await response.json();
+    return { data, ok: response.ok };
+}
+
 export const refreshToken = async () => {
     const response = await fetch('/api/auth/refresh', {
         method: 'POST', 

--- a/src/lib/api/membershipService.ts
+++ b/src/lib/api/membershipService.ts
@@ -73,7 +73,7 @@ export async function getUserMembership() {
 export async function validateCouponCode(memberId: number, couponCode: string) {
     try {
         // Send GET request to the backend
-        const response = await fetch(`http://localhost:3333/api/membership/${memberId}/apply-coupon`, {
+        const response = await fetch(`/api/membership/${memberId}/apply-coupon`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json', 
@@ -89,6 +89,24 @@ export async function validateCouponCode(memberId: number, couponCode: string) {
         return data; // Return the membership details for the authenticated user
     } catch (error: any) {
       throw new Error(error.message || 'An error occurred while applying coupon code');
+    }
+}
+
+export async function validateScholarshipCode(scholarshipCode: string) {
+    try {
+        const response = await fetch(`/api/coupon/validate/${encodeURIComponent(scholarshipCode)}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+        const data = await response.json();
+        if (!response.ok) {
+            throw new Error(data.message || 'Invalid scholarship code, please try again');
+        }
+        return data;
+    } catch (error: any) {
+        throw new Error(error.message || 'An error occurred while validating the scholarship code');
     }
 }
 

--- a/src/utils/stores.ts
+++ b/src/utils/stores.ts
@@ -17,6 +17,7 @@ export const membershipTypes = {
     "24-hours": "24-hours",
     "yearly-access": "yearly-access",
     "monthly-access": "monthly-access",
+    "basic": "basic",
     "scholarship": "scholarship"
 }
 


### PR DESCRIPTION
…reation

- Added Basic membership tier (free, limited access) to the membership selection step
- Free tiers (Basic, Scholarship) now skip the payment step and go directly to confirmation
- Scholarship selection shows an inline code validation input on the right panel
- Membership info panel updated: checkmark bullets, bold heading + description per benefit
- Yearly membership shows "most popular" badge; Scholarship row shows "Apply or redeem"
- Account is now created at the final confirmation step (POST /auth/complete-signup) instead of at email verification, so no DB record exists until signup is fully completed
- Confirmation page shows a loading spinner while the account is being created, then displays a dynamic message based on the selected membership type ("Your Monthly access is now active...")
- Atom reset moved to the "Log in" button click to prevent the success screen from unmounting itself
- Removed hardcoded localhost URLs from membershipService; scholarship code now validates against a public endpoint (no auth required)