### PR TITLE
fix: auto refresh expired access tokens in middleware and auth services

### DIFF
--- a/src/lib/api/authService.ts
+++ b/src/lib/api/authService.ts
@@ -1,9 +1,38 @@
+import { UserUpdateData } from "@/interfaces/profileInterface";
+
 interface ApiResponse<T = any> {
     data: T | null;
     ok: boolean;
     status: number;
     error?: string;
 }
+
+// ---------------------------------------------------------------------------
+// 🔑 HELPER: Handles client-side API requests with auto-refresh on 401
+// ---------------------------------------------------------------------------
+const fetchWithAuth = async (url: string, options: RequestInit = {}): Promise<Response> => {
+    let response = await fetch(url, {
+        ...options,
+        credentials: "include" // Always pass session cookies
+    });
+
+    // If access token expired (401), attempt to refresh and retry once
+    if (response.status === 401) {
+        const refreshRes = await refreshToken();
+        if (refreshRes.ok) {
+            response = await fetch(url, {
+                ...options,
+                credentials: "include"
+            });
+        }
+    }
+
+    return response;
+};
+
+// ---------------------------------------------------------------------------
+// Auth Methods
+// ---------------------------------------------------------------------------
 
 export const signup = async (
     fullName: string,
@@ -60,7 +89,7 @@ export const login = async (email: string, password: string): Promise<ApiRespons
         const response = await fetch("/api/auth/login", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            credentials: "include", // 👈 Crucial: ensures cookies from backend response are saved
+            credentials: "include",
             body: JSON.stringify({ email, password })
         });
         const data = await response.json().catch(() => null);
@@ -134,5 +163,39 @@ export const refreshToken = async (): Promise<ApiResponse> => {
     } catch (error: any) {
         console.error("Token Refresh Failed:", error);
         return { data: null, ok: false, status: 500, error: error.message };
+    }
+};
+
+// ---------------------------------------------------------------------------
+// User Methods
+// ---------------------------------------------------------------------------
+
+export const getUser = async (): Promise<ApiResponse> => {
+    try {
+        const response = await fetchWithAuth('/api/user/', {
+            method: "GET"
+        });
+        const data = await response.json().catch(() => null);
+        return { data, ok: response.ok, status: response.status };
+    } catch (err: any) {
+        console.error("Get User Failed:", err);
+        return { data: null, ok: false, status: 500, error: err.message };
+    }
+};
+
+export const updateUser = async (userData: UserUpdateData): Promise<ApiResponse> => {
+    try {
+        const response = await fetchWithAuth('/api/user/', {
+            method: "PUT",
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(userData)
+        });
+        const data = await response.json().catch(() => null);
+        return { data, ok: response.ok, status: response.status };
+    } catch (err: any) {
+        console.error("Update User Failed:", err);
+        return { data: null, ok: false, status: 500, error: err.message };
     }
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -27,15 +27,16 @@ export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('access_token')?.value;
   const refreshToken = request.cookies.get('refresh_token')?.value;
 
-  // Check backend session validity helper
   let isSessionValid = false;
+  let newSetCookieHeader: string | null = null;
 
+  // 2. Step 1: Check if current access token is valid
   if (accessToken) {
     try {
       const verifyResponse = await fetch(`${BACKEND_BASE_URL}/api/user/`, {
         method: 'GET',
         headers: {
-          Cookie: `access_token=${accessToken}; refresh_token=${refreshToken}`,
+          Cookie: `access_token=${accessToken}`,
         },
         credentials: 'include',
       });
@@ -49,15 +50,39 @@ export async function middleware(request: NextRequest) {
     }
   }
 
+  // 3. Step 2: 🔑 FIX HERE - If access_token failed/expired, attempt refresh!
+  if (!isSessionValid && refreshToken) {
+    try {
+      const refreshResponse = await fetch(`${BACKEND_BASE_URL}/api/auth/refresh`, {
+        method: 'POST',
+        headers: {
+          Cookie: `refresh_token=${refreshToken}`,
+        },
+        credentials: 'include',
+      });
+
+      if (refreshResponse.status === 200) {
+        isSessionValid = true;
+        // Capture the new set-cookie header sent back by the backend refresh route
+        newSetCookieHeader = refreshResponse.headers.get('set-cookie');
+      }
+    } catch (error) {
+      console.error('Error refreshing token in middleware:', error);
+      isSessionValid = false;
+    }
+  }
+
   // --- SCENARIO A: User is trying to access Auth pages (/login, /signup) ---
   if (pathname === '/login' || pathname === '/signup') {
-    // If user is ALREADY logged in and presses BACK arrow to /login -> redirect to /dashboard
     if (isSessionValid) {
       const response = NextResponse.redirect(new URL('/dashboard', request.url));
       response.headers.set(
         'Cache-Control',
         'no-store, no-cache, must-revalidate, proxy-revalidate'
       );
+      if (newSetCookieHeader) {
+        response.headers.set('Set-Cookie', newSetCookieHeader);
+      }
       return response;
     }
     return NextResponse.next();
@@ -65,7 +90,6 @@ export async function middleware(request: NextRequest) {
 
   // --- SCENARIO B: User is trying to access Protected routes (/dashboard, /account) ---
   if (!isSessionValid) {
-    // If user logged out and presses FORWARD arrow -> redirect to /login
     const response = NextResponse.redirect(new URL('/login', request.url));
     response.headers.set(
       'Cache-Control',
@@ -74,16 +98,19 @@ export async function middleware(request: NextRequest) {
     return response;
   }
 
-  // Allow normal access with no-cache headers to prevent bfcache issues
+  // Allow normal access, forwarding newly refreshed cookies if updated
   const response = NextResponse.next();
   response.headers.set(
     'Cache-Control',
     'no-store, no-cache, must-revalidate, proxy-revalidate'
   );
+  if (newSetCookieHeader) {
+    response.headers.set('Set-Cookie', newSetCookieHeader);
+  }
+
   return response;
 }
 
-// Ensure middleware runs for auth pages AND protected pages
 export const config = {
   matcher: ['/login', '/signup', '/dashboard/:path*', '/account/:path*'],
 };


### PR DESCRIPTION
**Summary**
Resolves the issue where active users were automatically logged out and redirected to /login when navigating or making API requests after their access token expired.

**Changes Made**
middleware.ts: Updated the session verification flow to automatically call /api/auth/refresh when the access_token check fails (due to expiration) and a refresh_token cookie is present. Attached updated Set-Cookie headers to the response to seamlessly update the session on page navigations.

authService.ts: Created a fetchWithAuth wrapper function that catches 401 Unauthorized responses on client-side requests, triggers a silent token refresh, and automatically retries the failed API call. Updated getUser and updateUser methods to use this wrapper.

**How to Test**
Log into the application.

Wait for the short access token lifetime to expire (5 minutes).

Navigate between protected pages (/dashboard, /account).

Perform in-page actions that make user API requests.

Expected Result: The user remains logged in seamlessly, and session cookies refresh in the background without forcing a redirect to /login.